### PR TITLE
Update broken link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ From source::
 Alternatives
 ------------
 
-* `csvkit.csvsql <https://csvkit.readthedocs.org/en/0.7.3/scripts/csvsql.html>`_
+* `csvkit.csvsql <https://csvkit.readthedocs.io/en/latest/scripts/csvsql.html>`_
 * `pandas.read_*` methods
 * `prequel <https://github.com/timClicks/prequel.git>`_ for SQLite
 


### PR DESCRIPTION
The link to csvkit.csvsql pointed to an old version of the tool that is no longer available. This link is updated now.